### PR TITLE
hotfix: fix output format shorthand flag

### DIFF
--- a/cmd/hcledit/internal/command/read.go
+++ b/cmd/hcledit/internal/command/read.go
@@ -32,7 +32,7 @@ func NewCmdRead() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.OutputFormat, "output-format", "-o", "go-template='{{.Key}} {{.Value}}'", "format to print the value as")
+	cmd.Flags().StringVarP(&opts.OutputFormat, "output-format", "o", "go-template='{{.Key}} {{.Value}}'", "format to print the value as")
 
 	return cmd
 }


### PR DESCRIPTION
## WHAT
This PR fixes the shorthand flag for `output-format`

## WHY
Needs to be 1 character 🙏 