### PR TITLE
goreleaser: fix version ldflag

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,7 +9,7 @@ builds:
     env:
       - CGO_ENABLED=0
     ldflags:
-      - -s -w -X github.com/mercari/hcledit/cmd/hcledit.version={{.Version}}
+      - -s -w -X main.version={{.Version}}
     goos:
       - linux
       - windows


### PR DESCRIPTION
## WHAT
This PR fixes the `goreleaser` config that sets the `version` flag.

## WHY
```bash
# before
$ ./dist/hcledit_darwin_amd64/bin/hcledit version
dev

# after
$ ./dist/hcledit_darwin_amd64/bin/hcledit version
v0.0.4-next
```
