### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@ version: 2
 
 updates:
   - package-ecosystem: gomod
-    directory: /backend
+    directory: "/"
     schedule:
       interval: weekly
     open-pull-requests-limit: 5


### PR DESCRIPTION
## WHAT

Added a Dependadbot config.

## WHY

To manage Go modules for keeping them latest.
