### PR TITLE
Enable cache in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,20 +1,32 @@
 name: Test
+
 on:
   push:
-  pull_request:
-  workflow_dispatch:
+
 jobs:
   test:
     runs-on: ubuntu-latest
+
     strategy:
       matrix:
         go: [1.15.x]
+
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Setup Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: ${{ matrix.go }}
-    - name: Run test
-      run: go test -v ./...
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go }}
+
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Test
+        run: go test -v -race ./...


### PR DESCRIPTION
## WHAT

This PR enables caching Go modules with https://github.com/actions/cache.

## WHY

To make testing faster.
