### PR TITLE
Fix lint errors

### DIFF
--- a/cmd/hcledit/internal/command/create.go
+++ b/cmd/hcledit/internal/command/create.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/mercari/hcledit"
 	"github.com/spf13/cobra"
+
+	"github.com/mercari/hcledit"
 )
 
 type CreateOptions struct {
@@ -38,16 +39,16 @@ func runCreate(opts *CreateOptions, args []string) error {
 
 	editor, err := hcledit.ReadFile(filePath)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Failed to read file: %s\n", err)
+		return fmt.Errorf("failed to read file: %s", err)
 	}
 
 	value, err := convert(valueStr, opts.Type)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Failed to convert input to specific type: %s\n", err)
+		return fmt.Errorf("failed to convert input to specific type: %s", err)
 	}
 
 	if err := editor.Create(query, value); err != nil {
-		return fmt.Errorf("[ERROR] Failed to create: %s\n", err)
+		return fmt.Errorf("failed to create: %s", err)
 	}
 
 	return editor.OverWriteFile()
@@ -64,6 +65,6 @@ func convert(inputStr, typeStr string) (interface{}, error) {
 	case "raw":
 		return hcledit.RawVal(inputStr), nil
 	default:
-		return nil, fmt.Errorf("Unsupported type: %s", typeStr)
+		return nil, fmt.Errorf("unsupported type: %s", typeStr)
 	}
 }

--- a/cmd/hcledit/internal/command/delete.go
+++ b/cmd/hcledit/internal/command/delete.go
@@ -3,8 +3,9 @@ package command
 import (
 	"fmt"
 
-	"github.com/mercari/hcledit"
 	"github.com/spf13/cobra"
+
+	"github.com/mercari/hcledit"
 )
 
 func NewCmdDelete() *cobra.Command {
@@ -29,11 +30,11 @@ func runDelete(args []string) error {
 
 	editor, err := hcledit.ReadFile(filePath)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Failed to read file: %s\n", err)
+		return fmt.Errorf("failed to read file: %s", err)
 	}
 
 	if err := editor.Delete(query); err != nil {
-		return fmt.Errorf("[ERROR] Failed to delete: %s\n", err)
+		return fmt.Errorf("failed to delete: %s", err)
 	}
 
 	return editor.OverWriteFile()

--- a/cmd/hcledit/internal/command/read.go
+++ b/cmd/hcledit/internal/command/read.go
@@ -2,13 +2,15 @@ package command
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"text/template"
 
-	"github.com/mercari/hcledit"
 	"github.com/spf13/cobra"
 	yaml "gopkg.in/yaml.v2"
+
+	"github.com/mercari/hcledit"
 )
 
 type ReadOptions struct {
@@ -44,18 +46,18 @@ func runRead(opts *ReadOptions, args []string) (string, error) {
 
 	editor, err := hcledit.ReadFile(filePath)
 	if err != nil {
-		return "", fmt.Errorf("[ERROR] Failed to read file: %s\n", err)
+		return "", fmt.Errorf("failed to read file: %s", err)
 	}
 
 	results, err := editor.Read(query)
 	if err != nil {
-		return "", fmt.Errorf("[ERROR] Failed to read file: %s\n", err)
+		return "", fmt.Errorf("failed to read file: %s", err)
 	}
 
 	if strings.HasPrefix(opts.OutputFormat, "go-template") {
 		split := strings.SplitN(opts.OutputFormat, "=", 2)
 		if len(split) != 2 {
-			return "", fmt.Errorf(`[ERROR] go-template should be passed as go-template='<TEMPLATE>'`)
+			return "", errors.New("go-template should be passed as go-template='<TEMPLATE>'")
 		}
 
 		templateFormat := strings.Trim(split[1], "'")
@@ -90,5 +92,5 @@ func runRead(opts *ReadOptions, args []string) (string, error) {
 		return string(y), err
 	}
 
-	return "", fmt.Errorf("[ERROR] Invalid output-format")
+	return "", errors.New("invalid output-format")
 }

--- a/cmd/hcledit/internal/command/read_test.go
+++ b/cmd/hcledit/internal/command/read_test.go
@@ -94,10 +94,10 @@ func TestRunRead(t *testing.T) {
 	}
 
 	for name, tc := range cases {
+		tc := tc
 		t.Run(name, func(t *testing.T) {
 			args := []string{tc.query, fixture}
 			got, err := runRead(tc.opts, args)
-
 			if err != nil {
 				t.Fatalf("unexpected err %s", err)
 			}

--- a/cmd/hcledit/main.go
+++ b/cmd/hcledit/main.go
@@ -6,9 +6,7 @@ import (
 	"github.com/mercari/hcledit/cmd/hcledit/internal/command"
 )
 
-var (
-	version = "dev"
-)
+var version = "dev"
 
 func main() {
 	cmd := command.NewCmdRoot(version)

--- a/hcledit.go
+++ b/hcledit.go
@@ -73,13 +73,13 @@ func (h *hclEditImpl) Create(queryStr string, value interface{}, opts ...Option)
 		return err
 	}
 
-	handler, err := handler.New(value, opt.comment, opt.afterKey)
+	hdlr, err := handler.New(value, opt.comment, opt.afterKey)
 	if err != nil {
 		return err
 	}
 
 	w := &walker.Walker{
-		Handler: handler,
+		Handler: hdlr,
 		Mode:    walker.Create,
 	}
 	w.Walk(h.writeFile.Body(), queries, 0, []string{})
@@ -100,11 +100,14 @@ func (h *hclEditImpl) Read(queryStr string, opts ...Option) (map[string]interfac
 		return nil, err
 	}
 
-	results := make(map[string]cty.Value, 0)
-	handler, _ := handler.NewReadHandler(results)
+	results := make(map[string]cty.Value)
+	hdlr, err := handler.NewReadHandler(results)
+	if err != nil {
+		return nil, err
+	}
 
 	w := &walker.Walker{
-		Handler: handler,
+		Handler: hdlr,
 		Mode:    walker.Read,
 	}
 
@@ -135,13 +138,13 @@ func (h *hclEditImpl) Update(queryStr string, value interface{}, opts ...Option)
 		return err
 	}
 
-	handler, err := handler.New(value, opt.comment, opt.afterKey)
+	hdlr, err := handler.New(value, opt.comment, opt.afterKey)
 	if err != nil {
 		return err
 	}
 
 	w := &walker.Walker{
-		Handler: handler,
+		Handler: hdlr,
 		Mode:    walker.Update,
 	}
 
@@ -183,7 +186,7 @@ func (h *hclEditImpl) reload() error {
 }
 
 func convert(original map[string]cty.Value) (map[string]interface{}, error) {
-	results := make(map[string]interface{}, 0)
+	results := make(map[string]interface{})
 	for key, ctyVal := range original {
 		goVal, err := converter.FromCtyValueToGoValue(ctyVal)
 		if err != nil {

--- a/hcledit_test.go
+++ b/hcledit_test.go
@@ -140,6 +140,7 @@ object1 = {
 	}
 
 	for name, tc := range cases {
+		tc := tc
 		t.Run(name, func(t *testing.T) {
 			editor, err := hcledit.Read(strings.NewReader(tc.input), "")
 			if err != nil {
@@ -325,6 +326,7 @@ attribute = [true, false, true]
 	}
 
 	for name, tc := range cases {
+		tc := tc
 		t.Run(name, func(t *testing.T) {
 			editor, err := hcledit.Read(strings.NewReader(tc.input), "")
 			if err != nil {
@@ -639,6 +641,7 @@ attribute = [true, false, true]
 	}
 
 	for name, tc := range cases {
+		tc := tc
 		t.Run(name, func(t *testing.T) {
 			editor, err := hcledit.Read(strings.NewReader(tc.input), "")
 			if err != nil {
@@ -805,6 +808,7 @@ object1 = {
 	}
 
 	for name, tc := range cases {
+		tc := tc
 		t.Run(name, func(t *testing.T) {
 			editor, err := hcledit.Read(strings.NewReader(tc.input), "")
 			if err != nil {

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -84,11 +84,10 @@ func getKeysAndNewLines(tokens hclwrite.Tokens) ([]string, map[string]int) {
 		open     []hclsyntax.TokenType
 		newLines int
 	)
-Token:
 	for {
 		next := p.Peek()
 		if next.Type == hclsyntax.TokenEOF {
-			break Token
+			break
 		}
 		switch next.Type {
 		case hclsyntax.TokenIdent:

--- a/internal/ast/object.go
+++ b/internal/ast/object.go
@@ -6,8 +6,6 @@ import (
 
 // Object
 type Object struct {
-	name string
-
 	beforeTokens     hclwrite.Tokens
 	objectAtrributes []*ObjectAtrribute
 	afterTokens      hclwrite.Tokens
@@ -53,7 +51,7 @@ func (o *Object) SetObjectAttributeRaw(name string, exprTokens, commentTokens hc
 	if objAttr != nil {
 		objAttr.exprTokens = exprTokens
 	} else {
-		objAttr := newObjectAttribute(name, exprTokens, commentTokens)
+		objAttr = newObjectAttribute(name, exprTokens, commentTokens)
 		o.objectAtrributes = append(o.objectAtrributes, objAttr)
 	}
 	return objAttr

--- a/internal/ast/parser.go
+++ b/internal/ast/parser.go
@@ -23,11 +23,10 @@ func ParseObject(tokens hclwrite.Tokens) (*Object, error) {
 	}
 
 	var beforeTokens hclwrite.Tokens
-Token:
 	for {
 		next := p.Peek()
 		if next.Type == hclsyntax.TokenEOF {
-			break Token
+			break
 		}
 
 		switch next.Type {
@@ -86,20 +85,18 @@ func partitionObjectTokens(tokens hclwrite.Tokens) (hclwrite.Tokens, hclwrite.To
 
 // readBlock is only used to move peeker to end of the block expression.
 func readBlock(p *peeker) {
-BeforeToken:
 	for {
 		tok := p.Read()
 		if tok.Type == hclsyntax.TokenEOF || tok.Type == hclsyntax.TokenOBrace {
-			break BeforeToken
+			break
 		}
 	}
 
 	var open []hclsyntax.TokenType
-Token:
 	for {
 		next := p.Peek()
 		if next.Type == hclsyntax.TokenEOF {
-			break Token
+			break
 		}
 		switch next.Type {
 		case hclsyntax.TokenOBrace:
@@ -109,7 +106,7 @@ Token:
 			token := p.Read()
 			if len(open) == 0 {
 				p.Read() // eat newline Token
-				break Token
+				break
 			}
 
 			opener := oppositeBracket(token.Type)

--- a/internal/converter/converter.go
+++ b/internal/converter/converter.go
@@ -69,5 +69,5 @@ func FromCtyValueToGoValue(ctyVal cty.Value) (interface{}, error) {
 		}
 	}
 
-	return nil, fmt.Errorf("Unsupported cty type")
+	return nil, fmt.Errorf("unsupported cty type")
 }

--- a/internal/handler/block.go
+++ b/internal/handler/block.go
@@ -28,5 +28,5 @@ func (h *blockHandler) HandleBody(body *hclwrite.Body, name string, _ []string) 
 }
 
 func (h *blockHandler) HandleObject(_ *ast.Object, _ string, _ []string) error {
-	return fmt.Errorf("This function should not be called")
+	return fmt.Errorf("this function should not be called")
 }

--- a/internal/handler/raw.go
+++ b/internal/handler/raw.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
+
 	"github.com/mercari/hcledit/internal/ast"
 )
 
@@ -22,7 +23,8 @@ func newRawHandler(rawString string) (Handler, error) {
 				Type:  hclsyntax.TokenComment,
 				Bytes: []byte(rawString),
 			},
-		}}, nil
+		},
+	}, nil
 }
 
 func (h *rawHandler) HandleBody(body *hclwrite.Body, name string, _ []string) error {

--- a/option_test.go
+++ b/option_test.go
@@ -59,6 +59,7 @@ object = {
 	}
 
 	for name, tc := range cases {
+		tc := tc
 		t.Run(name, func(t *testing.T) {
 			editor, err := hcledit.Read(strings.NewReader(tc.input), "")
 			if err != nil {
@@ -154,6 +155,7 @@ block {
 	}
 
 	for name, tc := range cases {
+		tc := tc
 		t.Run(name, func(t *testing.T) {
 			editor, err := hcledit.Read(strings.NewReader(tc.input), "")
 			if err != nil {

--- a/write_test.go
+++ b/write_test.go
@@ -52,7 +52,7 @@ func TestOverWriteFile(t *testing.T) {
 	tempFile := filepath.Join(tempDir, "test.hcl")
 	if err := ioutil.WriteFile(tempFile, []byte(`
 attribute1 = "str1"
-`), 0666); err != nil {
+`), 0600); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
## WHAT

Fixed most of the lint errors by `golangci-lint`.

<details>
<summary><code>golangci-lint run</code></summary>

```console
$ golangci-lint run
internal/ast/ast.go:87:1: unlabelStmt: label Token is redundant (gocritic)
Token:
^
internal/ast/parser.go:26:1: unlabelStmt: label Token is redundant (gocritic)
Token:
^
internal/ast/parser.go:89:1: unlabelStmt: label BeforeToken is redundant (gocritic)
BeforeToken:
^
internal/ast/object.go:9:2: `name` is unused (structcheck)
        name string
        ^
internal/ast/object.go:56:3: shadow: declaration of "objAttr" shadows declaration at line 52 (govet)
                objAttr := newObjectAttribute(name, exprTokens, commentTokens)
                ^
internal/handler/block.go:31:9: ST1005: error strings should not be capitalized (stylecheck)
        return fmt.Errorf("This function should not be called")
               ^
internal/walker/walker.go:43:26: Error return value of `w.Handler.HandleBody` is not checked (errcheck)
                                        w.Handler.HandleBody(body, key, keytrail)
                                                            ^
internal/walker/walker.go:81:24: Error return value of `w.Handler.HandleBody` is not checked (errcheck)
                        w.Handler.HandleBody(body, key, keytrail)
                                            ^
internal/walker/walker.go:122:25: Error return value of `w.Handler.HandleBody` is not checked (errcheck)
                                w.Handler.HandleBody(body, "", keytrail)
                                                    ^
internal/walker/walker.go:141:28: Error return value of `w.Handler.HandleObject` is not checked (errcheck)
                                        w.Handler.HandleObject(obj, key, keytrail)
                                                              ^
internal/walker/walker.go:176:26: Error return value of `w.Handler.HandleObject` is not checked (errcheck)
                        w.Handler.HandleObject(obj, key, keytrail)
                                              ^
internal/walker/walker.go:94:3: shadow: declaration of "keytrail" shadows declaration at line 86 (govet)
                keytrail := append(keytrail, block.Type())
                ^
hcledit.go:64:16: Error return value of `h.reload` is not checked (errcheck)
        defer h.reload()
                      ^
hcledit.go:91:16: Error return value of `h.reload` is not checked (errcheck)
        defer h.reload()
                      ^
hcledit.go:116:16: Error return value of `h.reload` is not checked (errcheck)
        defer h.reload()
                      ^
hcledit.go:76:2: importShadow: shadow of imported from 'github.com/mercari/hcledit/internal/handler' package 'handler' (gocritic)
        handler, err := handler.New(value, opt.comment, opt.afterKey)
        ^
hcledit.go:104:2: importShadow: shadow of imported from 'github.com/mercari/hcledit/internal/handler' package 'handler' (gocritic)
        handler, _ := handler.NewReadHandler(results)
        ^
hcledit.go:138:2: importShadow: shadow of imported from 'github.com/mercari/hcledit/internal/handler' package 'handler' (gocritic)
        handler, err := handler.New(value, opt.comment, opt.afterKey)
        ^
hcledit.go:103:40: S1019: should use make(map[string]cty.Value) instead (gosimple)
        results := make(map[string]cty.Value, 0)
                                              ^
hcledit.go:186:42: S1019: should use make(map[string]interface{}) instead (gosimple)
        results := make(map[string]interface{}, 0)
                                                ^
cmd/hcledit/internal/command/read_test.go:98:21: Using the variable on range scope `tc` in function literal (scopelint)
                        args := []string{tc.query, fixture}
                                         ^
cmd/hcledit/internal/command/read_test.go:99:24: Using the variable on range scope `tc` in function literal (scopelint)
                        got, err := runRead(tc.opts, args)
                                            ^
cmd/hcledit/internal/command/read_test.go:104:14: Using the variable on range scope `tc` in function literal (scopelint)
                        if got != tc.want {
                                  ^
cmd/hcledit/internal/command/create.go:41:10: ST1005: error strings should not end with punctuation or a newline (stylecheck)
                return fmt.Errorf("[ERROR] Failed to read file: %s\n", err)
                       ^
cmd/hcledit/internal/command/create.go:46:10: ST1005: error strings should not end with punctuation or a newline (stylecheck)
                return fmt.Errorf("[ERROR] Failed to convert input to specific type: %s\n", err)
                       ^
cmd/hcledit/internal/command/create.go:50:10: ST1005: error strings should not end with punctuation or a newline (stylecheck)
                return fmt.Errorf("[ERROR] Failed to create: %s\n", err)
                       ^
cmd/hcledit/internal/command/create.go:67:15: ST1005: error strings should not be capitalized (stylecheck)
                return nil, fmt.Errorf("Unsupported type: %s", typeStr)
                            ^
internal/converter/converter.go:72:14: ST1005: error strings should not be capitalized (stylecheck)
        return nil, fmt.Errorf("Unsupported cty type")
                    ^
example_test.go:43:15: Error return value of `editor.Create` is not checked (errcheck)
        editor.Create("resource.google_container_node_pool.*.node_config.disk_size_gb", "200")
                     ^
example_test.go:46:15: Error return value of `editor.Create` is not checked (errcheck)
        editor.Create("resource.google_container_node_pool.*.master_auth", hcledit.BlockVal())
                     ^
example_test.go:47:15: Error return value of `editor.Create` is not checked (errcheck)
        editor.Create("resource.google_container_node_pool.*.master_auth.username", "")
                     ^
example_test.go:51:15: Error return value of `editor.Update` is not checked (errcheck)
        editor.Update("resource.google_container_node_pool.*.node_config.machine_type", "COS")
                     ^
example_test.go:52:15: Error return value of `editor.Update` is not checked (errcheck)
        editor.Update("resource.google_container_node_pool.*.node_config.preemptible", true)
                     ^
example_test.go:55:15: Error return value of `editor.Delete` is not checked (errcheck)
        editor.Delete("resource.google_container_node_pool.*.timeouts")
                     ^
write_test.go:53:12: G306: Expect WriteFile permissions to be 0600 or less (gosec)
        if err := ioutil.WriteFile(tempFile, []byte(`
attribute1 = "str1"
`), 0666); err != nil {


```

</details>

## WHY

To keep code quality.
