### PR TITLE
Add error logging to hcledit command

### DIFF
--- a/cmd/hcledit/main.go
+++ b/cmd/hcledit/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/mercari/hcledit/cmd/hcledit/internal/command"
@@ -14,6 +15,7 @@ func main() {
 	cmd := command.NewCmdRoot(version)
 
 	if err := cmd.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
## WHAT

Added an error logging to `hcledit` command.

Before:

```console
$ go run ./cmd/hcledit/main.go read
exit status 1

```

After:

```console
$ go run ./cmd/hcledit/main.go read
accepts 2 arg(s), received 0
exit status 1

```

## WHY

The current implementation doesn't print errors so users can't see the cause of errors.
