### PR TITLE
Replace module with go.mercari.io/hcledit

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,20 @@
 
 ## Install
 
+### Library
+
 Use go get:
 
 ```bash
-$ go get -u github.com/mercari/hcledit
+$ go get -u go.mercari.io/hcledit
+```
+
+### Binary
+
+Install binaries via [GitHub Releases][release] or `go get`:
+
+```bash
+$ go get -u go.mercari.io/hcledit/cmd/hcledit
 ```
 
 ## Examples

--- a/cmd/hcledit/internal/command/create.go
+++ b/cmd/hcledit/internal/command/create.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/mercari/hcledit"
+	"go.mercari.io/hcledit"
 )
 
 type CreateOptions struct {

--- a/cmd/hcledit/internal/command/delete.go
+++ b/cmd/hcledit/internal/command/delete.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/mercari/hcledit"
+	"go.mercari.io/hcledit"
 )
 
 func NewCmdDelete() *cobra.Command {

--- a/cmd/hcledit/internal/command/read.go
+++ b/cmd/hcledit/internal/command/read.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	yaml "gopkg.in/yaml.v2"
 
-	"github.com/mercari/hcledit"
+	"go.mercari.io/hcledit"
 )
 
 type ReadOptions struct {

--- a/cmd/hcledit/main.go
+++ b/cmd/hcledit/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/mercari/hcledit/cmd/hcledit/internal/command"
+	"go.mercari.io/hcledit/cmd/hcledit/internal/command"
 )
 
 var version = "dev"

--- a/example_test.go
+++ b/example_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/mercari/hcledit"
+	"go.mercari.io/hcledit"
 )
 
 func Example() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mercari/hcledit
+module go.mercari.io/hcledit
 
 go 1.15
 

--- a/hcledit.go
+++ b/hcledit.go
@@ -7,10 +7,10 @@ import (
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/zclconf/go-cty/cty"
 
-	"github.com/mercari/hcledit/internal/converter"
-	"github.com/mercari/hcledit/internal/handler"
-	"github.com/mercari/hcledit/internal/query"
-	"github.com/mercari/hcledit/internal/walker"
+	"go.mercari.io/hcledit/internal/converter"
+	"go.mercari.io/hcledit/internal/handler"
+	"go.mercari.io/hcledit/internal/query"
+	"go.mercari.io/hcledit/internal/walker"
 )
 
 // HCLEditor provides the interface of HCL editing.

--- a/hcledit_test.go
+++ b/hcledit_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/mercari/hcledit"
+	"go.mercari.io/hcledit"
 )
 
 func TestCreate(t *testing.T) {

--- a/internal/handler/block.go
+++ b/internal/handler/block.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2/hclwrite"
 
-	"github.com/mercari/hcledit/internal/ast"
+	"go.mercari.io/hcledit/internal/ast"
 )
 
 type BlockVal struct {

--- a/internal/handler/cty.go
+++ b/internal/handler/cty.go
@@ -4,7 +4,7 @@ import (
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/zclconf/go-cty/cty"
 
-	"github.com/mercari/hcledit/internal/ast"
+	"go.mercari.io/hcledit/internal/ast"
 )
 
 type ctyValueHandler struct {

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/zclconf/go-cty/cty/gocty"
 
-	"github.com/mercari/hcledit/internal/ast"
+	"go.mercari.io/hcledit/internal/ast"
 )
 
 type Handler interface {

--- a/internal/handler/raw.go
+++ b/internal/handler/raw.go
@@ -4,7 +4,7 @@ import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 
-	"github.com/mercari/hcledit/internal/ast"
+	"go.mercari.io/hcledit/internal/ast"
 )
 
 type RawVal struct {

--- a/internal/handler/read.go
+++ b/internal/handler/read.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/zclconf/go-cty/cty"
 
-	"github.com/mercari/hcledit/internal/ast"
+	"go.mercari.io/hcledit/internal/ast"
 )
 
 type readHandler struct {

--- a/internal/walker/walker.go
+++ b/internal/walker/walker.go
@@ -3,9 +3,9 @@ package walker
 import (
 	"github.com/hashicorp/hcl/v2/hclwrite"
 
-	"github.com/mercari/hcledit/internal/ast"
-	"github.com/mercari/hcledit/internal/handler"
-	"github.com/mercari/hcledit/internal/query"
+	"go.mercari.io/hcledit/internal/ast"
+	"go.mercari.io/hcledit/internal/handler"
+	"go.mercari.io/hcledit/internal/query"
 )
 
 type walkMode int

--- a/option_test.go
+++ b/option_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mercari/hcledit"
+	"go.mercari.io/hcledit"
 )
 
 func TestWithComment(t *testing.T) {

--- a/write_test.go
+++ b/write_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mercari/hcledit"
+	"go.mercari.io/hcledit"
 )
 
 func TestWriteFile(t *testing.T) {


### PR DESCRIPTION
## WHAT

Replaced the module `github.com/mercari/hcledit` with `go.mercari.io/hcledit`.

## WHY

Now that `go.mercari.io/hcledit` is hosted, it's time to replace the module with it.
