### PR TITLE
Add update command

### DIFF
--- a/cmd/hcledit/internal/command/root.go
+++ b/cmd/hcledit/internal/command/root.go
@@ -15,10 +15,13 @@ func NewCmdRoot(version string) *cobra.Command {
 
 	cmd.SetVersionTemplate(version)
 
-	cmd.AddCommand(NewCmdVersion(version))
-	cmd.AddCommand(NewCmdRead())
-	cmd.AddCommand(NewCmdCreate())
-	cmd.AddCommand(NewCmdDelete())
+	cmd.AddCommand(
+		NewCmdVersion(version),
+		NewCmdRead(),
+		NewCmdCreate(),
+		NewCmdUpdate(),
+		NewCmdDelete(),
+	)
 
 	return cmd
 }

--- a/cmd/hcledit/internal/command/update.go
+++ b/cmd/hcledit/internal/command/update.go
@@ -1,0 +1,42 @@
+package command
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"go.mercari.io/hcledit"
+)
+
+func NewCmdUpdate() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "update <query> <value> <file>",
+		Short: "Update the given field with a value",
+		Long:  `Runs an address query on a hcl file and update the given field with a value.`,
+		Args:  cobra.ExactArgs(3),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if err := runUpdate(args); err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+	return cmd
+}
+
+func runUpdate(args []string) error {
+	query := args[0]
+	value := args[1]
+	filePath := args[2]
+
+	editor, err := hcledit.ReadFile(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to read file: %s", err)
+	}
+
+	if err := editor.Update(query, value); err != nil {
+		return fmt.Errorf("failed to delete: %s", err)
+	}
+
+	return editor.OverWriteFile()
+}

--- a/cmd/hcledit/internal/command/update_test.go
+++ b/cmd/hcledit/internal/command/update_test.go
@@ -1,0 +1,44 @@
+package command
+
+import (
+	"io/ioutil"
+	"log"
+	"testing"
+)
+
+func TestRunUpdate(t *testing.T) {
+	filename := tempFile(t, `
+resource "google_container_node_pool" "nodes1" {
+  node_config {
+    preemptible  = false
+    machine_type = "e2-medium"
+  }
+}
+`)
+
+	args := []string{
+		"resource.google_container_node_pool.*.node_config.machine_type",
+		"e2-highmem-2",
+		filename,
+	}
+	if err := runUpdate(args); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ioutil.ReadFile(filename)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	want := `
+resource "google_container_node_pool" "nodes1" {
+  node_config {
+    preemptible  = false
+    machine_type = "e2-highmem-2"
+  }
+}
+`
+	if string(got) != want {
+		t.Fatalf("\ngot  %s\nwant %s", got, want)
+	}
+}


### PR DESCRIPTION
## WHAT

Added `update` subcommand.

```console
$ go run ./cmd/hcledit/main.go update 'module.my-module.source' 'dummy.tar.gz' ./cmd/hcledit/internal/command/fixture/file.tf

$ git --no-pager diff
diff --git a/cmd/hcledit/internal/command/fixture/file.tf b/cmd/hcledit/internal/command/fixture/file.tf
index 2d98c5c..34685de 100644
--- a/cmd/hcledit/internal/command/fixture/file.tf
+++ b/cmd/hcledit/internal/command/fixture/file.tf
@@ -1,5 +1,5 @@
 module "my-module" {
-  source = "source.tar.gz"
+  source = "dummy.tar.gz"

   bool_variable   = true
   int_variable    = 1

```

## WHY

We plan to provide subcommands corresponding to CRUD.
