### PR TITLE
Add --with-after flag to create subcommand

### DIFF
--- a/cmd/hcledit/internal/command/create.go
+++ b/cmd/hcledit/internal/command/create.go
@@ -10,7 +10,8 @@ import (
 )
 
 type CreateOptions struct {
-	Type string
+	Type      string
+	WithAfter string
 }
 
 func NewCmdCreate() *cobra.Command {
@@ -29,6 +30,7 @@ func NewCmdCreate() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&opts.Type, "type", "t", "string", "Type of the value")
+	cmd.Flags().StringVar(&opts.WithAfter, "with-after", "string", "Field key which before the value will be created")
 	return cmd
 }
 
@@ -47,7 +49,7 @@ func runCreate(opts *CreateOptions, args []string) error {
 		return fmt.Errorf("failed to convert input to specific type: %s", err)
 	}
 
-	if err := editor.Create(query, value); err != nil {
+	if err := editor.Create(query, value, hcledit.WithAfter(opts.WithAfter)); err != nil {
 		return fmt.Errorf("failed to create: %s", err)
 	}
 

--- a/cmd/hcledit/internal/command/create_test.go
+++ b/cmd/hcledit/internal/command/create_test.go
@@ -1,0 +1,70 @@
+package command
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestRunCreate(t *testing.T) {
+	cases := map[string]struct {
+		opts    *CreateOptions
+		want    string
+		wantErr bool
+	}{
+		"WithoutOptionWithAfter": {
+			opts: &CreateOptions{
+				Type: "string",
+			},
+			want: `resource "google_container_node_pool" "nodes1" {
+  node_config {
+    preemptible  = false
+    machine_type = "e2-medium"
+    disk_size_gb = "100"
+  }
+}
+`,
+		},
+		"WithOptionWithAfter": {
+			opts: &CreateOptions{
+				Type:      "string",
+				WithAfter: "preemptible",
+			},
+			want: `resource "google_container_node_pool" "nodes1" {
+  node_config {
+    preemptible  = false
+    disk_size_gb = "100"
+    machine_type = "e2-medium"
+  }
+}
+`,
+		},
+	}
+
+	for name, tc := range cases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			filename := tempFile(t, `resource "google_container_node_pool" "nodes1" {
+  node_config {
+    preemptible  = false
+    machine_type = "e2-medium"
+  }
+}
+`)
+
+			if err := runCreate(tc.opts, []string{
+				"resource.google_container_node_pool.nodes1.node_config.disk_size_gb",
+				"100",
+				filename,
+			},
+			); (err != nil) != tc.wantErr {
+				t.Errorf("runCreate() error = %v, wantErr %v", err, tc.wantErr)
+			}
+
+			got := readFile(t, filename)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("(-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/cmd/hcledit/internal/command/root_test.go
+++ b/cmd/hcledit/internal/command/root_test.go
@@ -22,3 +22,14 @@ func tempFile(t *testing.T, contents string) string {
 	}
 	return f.Name()
 }
+
+func readFile(t *testing.T, filename string) string {
+	t.Helper()
+
+	b, err := ioutil.ReadFile(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return string(b)
+}


### PR DESCRIPTION
## WHAT

Added `--with-after` flag to `hcledit create` subcommand.

```console
// With `--with-after`
$ go run ./cmd/hcledit/main.go create 'module.my-module.key' 'value' ./cmd/hcledit/internal/command/fixture/file.tf --with-after 'source'

$ git --no-pager diff
diff --git a/cmd/hcledit/internal/command/fixture/file.tf b/cmd/hcledit/internal/command/fixture/file.tf
index 2d98c5c..a99f451 100644
--- a/cmd/hcledit/internal/command/fixture/file.tf
+++ b/cmd/hcledit/internal/command/fixture/file.tf
@@ -1,5 +1,6 @@
 module "my-module" {
   source = "source.tar.gz"
+  key    = "value"

   bool_variable   = true
   int_variable    = 1

// Without `--with-after`
$ go run ./cmd/hcledit/main.go create 'module.my-module.key' 'value' ./cmd/hcledit/internal/command/fixture/file.tf

$ git --no-pager diff
diff --git a/cmd/hcledit/internal/command/fixture/file.tf b/cmd/hcledit/internal/command/fixture/file.tf
index 2d98c5c..e726f13 100644
--- a/cmd/hcledit/internal/command/fixture/file.tf
+++ b/cmd/hcledit/internal/command/fixture/file.tf
@@ -29,4 +29,5 @@ module "my-module" {
       "f",
     ]
   }
+  key = "value"
 }

```

## WHY

From: https://github.com/mercari/hcledit/issues/6
