### PR TITLE
Add homebrew installation

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -33,3 +33,10 @@ changelog:
       - '^test:'      
       - Merge pull request
       - Merge branch
+brews:
+  - tap:
+      owner: mercari
+      name: hcledit
+    folder: Formula
+    homepage: https://github.com/mercari/hcledit
+    description: CLI to edit HCL configurations

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ### Go package
 
-Use go get:
+`go get`:
 
 ```bash
 $ go get -u go.mercari.io/hcledit
@@ -19,7 +19,16 @@ $ go get -u go.mercari.io/hcledit
 
 ### Binary
 
-Install binaries via [GitHub Releases][release] or `go get`:
+Install binaries via [GitHub Releases][release] or below:
+
+Homebrew:
+
+```bash
+$ brew tap mercari/hcledit https://github.com/mercari/hcledit
+$ brew install hcledit
+```
+
+`go get`:
 
 ```bash
 $ go get -u go.mercari.io/hcledit/cmd/hcledit


### PR DESCRIPTION
## WHAT

Added installation by Homebrew via GoReleaser.

Ref: https://goreleaser.com/customization/homebrew/

## WHY

To provide users more ways of installation.
