### PR TITLE
Rename --with-after flag to --after

### DIFF
--- a/cmd/hcledit/internal/command/create.go
+++ b/cmd/hcledit/internal/command/create.go
@@ -10,8 +10,8 @@ import (
 )
 
 type CreateOptions struct {
-	Type      string
-	WithAfter string
+	Type  string
+	After string
 }
 
 func NewCmdCreate() *cobra.Command {
@@ -30,7 +30,7 @@ func NewCmdCreate() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&opts.Type, "type", "t", "string", "Type of the value")
-	cmd.Flags().StringVar(&opts.WithAfter, "with-after", "string", "Field key which before the value will be created")
+	cmd.Flags().StringVarP(&opts.After, "after", "a", "", "Field key which before the value will be created")
 	return cmd
 }
 
@@ -49,7 +49,7 @@ func runCreate(opts *CreateOptions, args []string) error {
 		return fmt.Errorf("failed to convert input to specific type: %s", err)
 	}
 
-	if err := editor.Create(query, value, hcledit.WithAfter(opts.WithAfter)); err != nil {
+	if err := editor.Create(query, value, hcledit.WithAfter(opts.After)); err != nil {
 		return fmt.Errorf("failed to create: %s", err)
 	}
 

--- a/cmd/hcledit/internal/command/create_test.go
+++ b/cmd/hcledit/internal/command/create_test.go
@@ -27,8 +27,8 @@ func TestRunCreate(t *testing.T) {
 		},
 		"WithOptionWithAfter": {
 			opts: &CreateOptions{
-				Type:      "string",
-				WithAfter: "preemptible",
+				Type:  "string",
+				After: "preemptible",
 			},
 			want: `resource "google_container_node_pool" "nodes1" {
   node_config {


### PR DESCRIPTION
## WHAT

Renamed `--with-after` flag to `--after` for `hcledit create`. Also, added a shorthand `-a` and update the wrong default value for the option.

## WHY

To make the flag clearer.
