### PR TITLE
Add --comment flag to create subcommand

### DIFF
--- a/cmd/hcledit/internal/command/create.go
+++ b/cmd/hcledit/internal/command/create.go
@@ -10,8 +10,9 @@ import (
 )
 
 type CreateOptions struct {
-	Type  string
-	After string
+	Type    string
+	After   string
+	Comment string
 }
 
 func NewCmdCreate() *cobra.Command {
@@ -31,6 +32,7 @@ func NewCmdCreate() *cobra.Command {
 
 	cmd.Flags().StringVarP(&opts.Type, "type", "t", "string", "Type of the value")
 	cmd.Flags().StringVarP(&opts.After, "after", "a", "", "Field key which before the value will be created")
+	cmd.Flags().StringVarP(&opts.Comment, "comment", "c", "", "Comment to be inserted before the field added. Comment symbols like // are required")
 	return cmd
 }
 
@@ -49,7 +51,7 @@ func runCreate(opts *CreateOptions, args []string) error {
 		return fmt.Errorf("failed to convert input to specific type: %s", err)
 	}
 
-	if err := editor.Create(query, value, hcledit.WithAfter(opts.After)); err != nil {
+	if err := editor.Create(query, value, hcledit.WithAfter(opts.After), hcledit.WithComment(opts.Comment)); err != nil {
 		return fmt.Errorf("failed to create: %s", err)
 	}
 

--- a/cmd/hcledit/internal/command/create_test.go
+++ b/cmd/hcledit/internal/command/create_test.go
@@ -12,10 +12,8 @@ func TestRunCreate(t *testing.T) {
 		want    string
 		wantErr bool
 	}{
-		"WithoutOptionWithAfter": {
-			opts: &CreateOptions{
-				Type: "string",
-			},
+		"WithoutAdditionalOptions": {
+			opts: &CreateOptions{},
 			want: `resource "google_container_node_pool" "nodes1" {
   node_config {
     preemptible  = false
@@ -39,6 +37,20 @@ func TestRunCreate(t *testing.T) {
 }
 `,
 		},
+		"WithOptionComment": {
+			opts: &CreateOptions{
+				Comment: "// TODO: Testing",
+			},
+			want: `resource "google_container_node_pool" "nodes1" {
+  node_config {
+    preemptible  = false
+    machine_type = "e2-medium"
+    // TODO: Testing
+    disk_size_gb = "100"
+  }
+}
+`,
+		},
 	}
 
 	for name, tc := range cases {
@@ -52,6 +64,7 @@ func TestRunCreate(t *testing.T) {
 }
 `)
 
+			tc.opts.Type = "string" // ensure default value
 			if err := runCreate(tc.opts, []string{
 				"resource.google_container_node_pool.nodes1.node_config.disk_size_gb",
 				"100",


### PR DESCRIPTION
## WHAT

Added `--comment|-c` flag to `hclecit create`.

```console
$ go run ./cmd/hcledit/main.go create 'module.my-module.key' 'value' --comment '// Comment' ./cmd/hcledit/internal/command/fixture/file.tf

$ git --no-pager diff
diff --git a/cmd/hcledit/internal/command/fixture/file.tf b/cmd/hcledit/internal/command/fixture/file.tf
index 2d98c5c..7efd30b 100644
--- a/cmd/hcledit/internal/command/fixture/file.tf
+++ b/cmd/hcledit/internal/command/fixture/file.tf
@@ -29,4 +29,6 @@ module "my-module" {
       "f",
     ]
   }
+  // Comment
+  key = "value"
 }

```

## WHY

From: https://github.com/mercari/hcledit/issues/6
