### PR TITLE
Update docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,8 @@ name: Docker
 on:
   push:
     tags:
-      - '*'
+      # TODO(micnncim): Update this tag filter when making this repository public
+      - '_stable'
 
 jobs:
   docker:


### PR DESCRIPTION
## WHAT

Updated the workflow to build and push a Docker image to prevent it from working until we make this repository public.

## WHY

Even when this repository is private, Docker images will be pushed to Docker Hub once a new tag is created.
