### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,44 +2,24 @@
 
 [![workflow-test][workflow-test-badge]][workflow-test]
 [![release][release-badge]][release]
-[![docker][docker-badge]][docker]
 [![pkg.go.dev][pkg.go.dev-badge]][pkg.go.dev]
 [![license][license-badge]][license]
 
-`hcledit` is a Go package to edit HCL configurations. Basically, this is just a wrapper of [`hclwrite`](https://pkg.go.dev/github.com/hashicorp/hcl/v2/hclwrite) package which provides low-level features of generating HCL configurations. But `hcledit` allows you to access HCL attribute or block by [`jq`](https://github.com/stedolan/jq)-like query and do various manipulations. See examples of how it works.
+`hcledit` is a Go package to edit HCL configurations. Basically, this is just a wrapper of [`hclwrite`](https://pkg.go.dev/github.com/hashicorp/hcl/v2/hclwrite) package which provides low-level features of generating HCL configurations. But `hcledit` allows you to access HCL attribute or block by [`jq`](https://github.com/stedolan/jq)-like query and do various manipulations. See examples of how it works. 
+
+We provide simple CLI application based on this package. See [`hcledit` command](cmd/hcledit/README.md).
 
 ## Install
 
-### Go package
-
-`go get`:
+Use `go get`:
 
 ```bash
 $ go get -u go.mercari.io/hcledit
 ```
 
-### Binary
+## Usage
 
-Install binaries via [GitHub Releases][release] or below:
-
-Homebrew:
-
-```bash
-$ brew tap mercari/hcledit https://github.com/mercari/hcledit
-$ brew install hcledit
-```
-
-`go get`:
-
-```bash
-$ go get -u go.mercari.io/hcledit/cmd/hcledit
-```
-
-Docker:
-
-```bash
-$ docker run --rm -it mercari/hcledit hcledit
-```
+See [Go doc][pkg.go.dev].
 
 ## Examples
 
@@ -55,45 +35,13 @@ resource "google_container_node_pool" "nodes1" {
    }
 }
 ```
-### Go package
 
 To create a new attribute,
 
 ```go
 editor, _ := hcledit.Read(filename)
-editor.Create("resource.google_container_node_pool.*.node_config.disk_size_gb", "200")
+editor.Create("resource.google_container_node_pool.*.node_config.image_type", "COS")
 editor.OverWriteFile()
-```
-
-To update the existing attribute,
-
-```go
-editor, _ := hcledit.Read(filename)
-editor.Update("resource.google_container_node_pool.*.node_config.machine_type", "e2-highmem-2")
-editor.OverWriteFile()
-```
-
-To delete the existing attribute,
-
-```go
-editor, _ := hcledit.Read(filename)
-editor.Delete("resource.google_container_node_pool.*.node_config.preemptible")
-editor.OverWriteFile()
-```
-
-### Binary
-
-To read an attribute,
-
-```console
-$ hcledit read 'resource.google_container_node_pool.*.node_config.machine_type' /path/to/file.tf
-resource.google_container_node_pool.nodes1.node_config.machine_type e2-medium
-```
-
-To create a new attribute,
-
-```console
-$ hcledit create 'resource.google_container_node_pool.*.node_config.image_type' 'COS' /path/to/file.tf
 ```
 
 ```diff
@@ -110,8 +58,10 @@ resource "google_container_node_pool" "nodes1" {
 
 To update the existing attribute,
 
-```console
-$ hcledit update 'resource.google_container_node_pool.*.node_config.machine_type' 'e2-highmem-2' /path/to/file.tf
+```go
+editor, _ := hcledit.Read(filename)
+editor.Update("resource.google_container_node_pool.*.node_config.machine_type", "e2-highmem-2")
+editor.OverWriteFile()
 ```
 
 ```diff
@@ -128,8 +78,10 @@ resource "google_container_node_pool" "nodes1" {
 
 To delete the existing attribute,
 
-```console
-$ hcledit delete 'resource.google_container_node_pool.*.node_config.machine_type' /path/to/file.tf
+```go
+editor, _ := hcledit.Read(filename)
+editor.Delete("resource.google_container_node_pool.*.node_config.machine_type")
+editor.OverWriteFile()
 ```
 
 ```diff
@@ -150,9 +102,6 @@ resource "google_container_node_pool" "nodes1" {
 
 [release]: https://github.com/mercari/hcledit/releases
 [release-badge]: https://img.shields.io/github/v/release/mercari/hcledit?style=for-the-badge&logo=github
-
-[docker]: https://hub.docker.com/r/mercari/hcledit
-[docker-badge]: https://img.shields.io/docker/v/mercari/hcledit?label=docker&sort=semver&style=for-the-badge&logo=docker
 
 [pkg.go.dev]: https://pkg.go.dev/go.mercari.io/hcledit
 [pkg.go.dev-badge]: http://bit.ly/pkg-go-dev-badge

--- a/cmd/hcledit/README.md
+++ b/cmd/hcledit/README.md
@@ -1,0 +1,112 @@
+# hcledit command
+
+[![release][release-badge]][release]
+[![docker][docker-badge]][docker]
+
+`hcledit` command is a CLI tool to edit HCL configuration, which exposes [`hcledit`](https://pkg.go.dev/go.mercari.io/hcledit) API as command line interface. You can think this as a sample application built by the package.
+
+## Install
+
+Install binaries via [GitHub Releases][release] or below:
+
+Homebrew:
+
+```bash
+$ brew tap mercari/hcledit https://github.com/mercari/hcledit
+$ brew install hcledit
+```
+
+`go get`:
+
+```bash
+$ go get -u go.mercari.io/hcledit/cmd/hcledit
+```
+
+Docker:
+
+```bash
+$ docker run --rm -it mercari/hcledit hcledit
+```
+
+## Examples
+
+The following is an HCL configuration which we want to manipulate.
+
+```hcl
+resource "google_container_node_pool" "nodes1" {
+   name = "nodes1"
+
+   node_config {
+     preemptible  = false
+     machine_type = "e2-medium"
+   }
+}
+```
+
+To read an attribute,
+
+```console
+$ hcledit read 'resource.google_container_node_pool.*.node_config.machine_type' /path/to/file.tf
+resource.google_container_node_pool.nodes1.node_config.machine_type e2-medium
+```
+
+To create a new attribute,
+
+```console
+$ hcledit create 'resource.google_container_node_pool.*.node_config.image_type' 'COS' /path/to/file.tf
+```
+
+```diff
+resource "google_container_node_pool" "nodes1" {
+   name = "nodes1"
+
+   node_config {
+     preemptible  = false
+     machine_type = "e2-medium"
++    image_type   = "COS"
+   }
+}
+```
+
+To update the existing attribute,
+
+```console
+$ hcledit update 'resource.google_container_node_pool.*.node_config.machine_type' 'e2-highmem-2' /path/to/file.tf
+```
+
+```diff
+resource "google_container_node_pool" "nodes1" {
+   name = "nodes1"
+
+   node_config {
+     preemptible  = false
+-    machine_type = "e2-medium"
++    machine_type = "e2-highmem-2"
+   }
+}
+```
+
+To delete the existing attribute,
+
+```console
+$ hcledit delete 'resource.google_container_node_pool.*.node_config.machine_type' /path/to/file.tf
+```
+
+```diff
+resource "google_container_node_pool" "nodes1" {
+   name = "nodes1"
+
+   node_config {
+     preemptible  = false
+-    machine_type = "e2-medium"
+   }
+}
+```
+
+<!-- badge links -->
+
+[release]: https://github.com/mercari/hcledit/releases
+[release-badge]: https://img.shields.io/github/v/release/mercari/hcledit?style=for-the-badge&logo=github
+
+[docker]: https://hub.docker.com/r/mercari/hcledit
+[docker-badge]: https://img.shields.io/docker/v/mercari/hcledit?label=docker&sort=semver&style=for-the-badge&logo=docker


### PR DESCRIPTION
## WHAT

Update documentation

- Move `hcledit` command related documentation into `cmd/hcledit` directory
- Have same example both package and CLI

## WHY

I'm thinking the main content of this repository is `hcledit` package itself and CLI is one application based on it. So I want to separate doc for each and make it clear. 
