### PR TITLE
Enable docker image push for releases

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,8 +3,7 @@ name: Docker
 on:
   push:
     tags:
-      # TODO(micnncim): Update this tag filter when making this repository public
-      - '_stable'
+      - '*'
 
 jobs:
   docker:


### PR DESCRIPTION
## WHAT

SSIA.

## WHY

To push images to a public repository under https://hub.docker.com/u/mercari.
