### PR TITLE
Use secret for docker username in workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v1 
         with:
-          username: ${{ github.repository_owner }}
+          username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Output version


### PR DESCRIPTION
## WHAT

Use a secret value for the username instead of the repository owner.

## WHY

In our workflow, the username for Docker Hub is `mercaribot`, not `mercari`. The repository owner is `mercari` so it didn't work.
