### PR TITLE
Add version and revision at build time to version command

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,7 +9,9 @@ builds:
     env:
       - CGO_ENABLED=0
     ldflags:
-      - -s -w -X main.version={{.Version}}
+      - -s -w
+      - -X go.mercari.io/hcledit/cmd/hcledit/internal/version.Version={{.Tag}}
+      - -X go.mercari.io/hcledit/cmd/hcledit/internal/version.Revision={{.ShortCommit}}
     goos:
       - linux
       - windows

--- a/cmd/hcledit/internal/command/root.go
+++ b/cmd/hcledit/internal/command/root.go
@@ -4,7 +4,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NewCmdRoot(version string) *cobra.Command {
+func NewCmdRoot() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "hcledit <command> <subcommand> [flags]",
 		Short:         "",
@@ -13,10 +13,8 @@ func NewCmdRoot(version string) *cobra.Command {
 		SilenceUsage:  true,
 	}
 
-	cmd.SetVersionTemplate(version)
-
 	cmd.AddCommand(
-		NewCmdVersion(version),
+		NewCmdVersion(),
 		NewCmdRead(),
 		NewCmdCreate(),
 		NewCmdUpdate(),

--- a/cmd/hcledit/internal/command/version.go
+++ b/cmd/hcledit/internal/command/version.go
@@ -4,14 +4,16 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+
+	"go.mercari.io/hcledit/cmd/hcledit/internal/version"
 )
 
-func NewCmdVersion(version string) *cobra.Command {
+func NewCmdVersion() *cobra.Command {
 	return &cobra.Command{
-		Use:    "version",
-		Hidden: true,
+		Use:   "version",
+		Short: "Show the version and revision",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println(version)
+			fmt.Printf("%s (%s)\n", version.Version, version.Revision)
 		},
 	}
 }

--- a/cmd/hcledit/internal/version/version.go
+++ b/cmd/hcledit/internal/version/version.go
@@ -1,0 +1,7 @@
+package version
+
+// Dynamically overridden at build time. See `ldflags` in .goreleaser.yml.
+var (
+	Version  = "dev"
+	Revision = "dev"
+)

--- a/cmd/hcledit/main.go
+++ b/cmd/hcledit/main.go
@@ -7,10 +7,8 @@ import (
 	"go.mercari.io/hcledit/cmd/hcledit/internal/command"
 )
 
-var version = "dev"
-
 func main() {
-	cmd := command.NewCmdRoot(version)
+	cmd := command.NewCmdRoot()
 
 	if err := cmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)


### PR DESCRIPTION
## WHAT

This PR allows `hcledit version` to show its version from a Git tag and revision from a Git commit determined at build time.

ref: https://goreleaser.com/customization/build

## WHY

To show more information to users and let us investigate issues when something is wrong.
