### PR TITLE
Output only the value as default

### DIFF
--- a/cmd/hcledit/internal/command/read.go
+++ b/cmd/hcledit/internal/command/read.go
@@ -35,7 +35,7 @@ func NewCmdRead() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.OutputFormat, "output-format", "o", "go-template='{{.Key}} {{.Value}}'", "format to print the value as")
+	cmd.Flags().StringVarP(&opts.OutputFormat, "output-format", "o", "go-template='{{.Value}}'", "format to print the value as")
 
 	return cmd
 }


### PR DESCRIPTION
## WHAT

As default, I only want the value to be displayed.

## WHY

I saw many users (including Mercari engineers) use with ` -o go-template="{{.Value}}"` every time because they only need the value like `jq`. 