### PR TITLE
Support --type flag in update command

### DIFF
--- a/cmd/hcledit/internal/command/create.go
+++ b/cmd/hcledit/internal/command/create.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/spf13/cobra"
 
@@ -52,19 +51,4 @@ func runCreate(opts *CreateOptions, args []string) error {
 	}
 
 	return editor.OverWriteFile()
-}
-
-func convert(inputStr, typeStr string) (interface{}, error) {
-	switch typeStr {
-	case "string":
-		return inputStr, nil
-	case "int":
-		return strconv.Atoi(inputStr)
-	case "bool":
-		return strconv.ParseBool(inputStr)
-	case "raw":
-		return hcledit.RawVal(inputStr), nil
-	default:
-		return nil, fmt.Errorf("unsupported type: %s", typeStr)
-	}
 }

--- a/cmd/hcledit/internal/command/root.go
+++ b/cmd/hcledit/internal/command/root.go
@@ -1,7 +1,11 @@
 package command
 
 import (
+	"fmt"
+	"strconv"
+
 	"github.com/spf13/cobra"
+	"go.mercari.io/hcledit"
 )
 
 func NewCmdRoot() *cobra.Command {
@@ -22,4 +26,19 @@ func NewCmdRoot() *cobra.Command {
 	)
 
 	return cmd
+}
+
+func convert(inputStr, typeStr string) (interface{}, error) {
+	switch typeStr {
+	case "string":
+		return inputStr, nil
+	case "int":
+		return strconv.Atoi(inputStr)
+	case "bool":
+		return strconv.ParseBool(inputStr)
+	case "raw":
+		return hcledit.RawVal(inputStr), nil
+	default:
+		return nil, fmt.Errorf("unsupported type: %s", typeStr)
+	}
 }

--- a/cmd/hcledit/internal/command/update.go
+++ b/cmd/hcledit/internal/command/update.go
@@ -8,24 +8,38 @@ import (
 	"go.mercari.io/hcledit"
 )
 
+type UpdateOptions struct {
+	Type string
+}
+
 func NewCmdUpdate() *cobra.Command {
-	return &cobra.Command{
+	opts := &UpdateOptions{}
+	cmd := &cobra.Command{
 		Use:   "update <query> <value> <file>",
 		Short: "Update the given field with a value",
 		Long:  `Runs an address query on a hcl file and update the given field with a value.`,
 		Args:  cobra.ExactArgs(3),
 		RunE: func(_ *cobra.Command, args []string) error {
-			return runUpdate(args)
+			return runUpdate(opts, args)
 		},
 	}
+
+	cmd.Flags().StringVarP(&opts.Type, "type", "t", "string", "Type of the value")
+
+	return cmd
 }
 
-func runUpdate(args []string) error {
-	query, value, filePath := args[0], args[1], args[2]
+func runUpdate(opts *UpdateOptions, args []string) error {
+	query, valueStr, filePath := args[0], args[1], args[2]
 
 	editor, err := hcledit.ReadFile(filePath)
 	if err != nil {
 		return fmt.Errorf("failed to read file: %s", err)
+	}
+
+	value, err := convert(valueStr, opts.Type)
+	if err != nil {
+		return fmt.Errorf("failed to convert input to specific type: %s", err)
 	}
 
 	if err := editor.Update(query, value); err != nil {

--- a/cmd/hcledit/internal/command/update_test.go
+++ b/cmd/hcledit/internal/command/update_test.go
@@ -25,7 +25,7 @@ resource "google_container_node_pool" "nodes1" {
 		filename,
 	}
 
-	if err := runUpdate(args); err != nil {
+	if err := runUpdate(&UpdateOptions{Type: "string"}, args); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
Adds the `--type` flag same as the `create` command to the `update` command.