### PR TITLE
add customedit function

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Lint
-        uses: reviewdog/action-golangci-lint@v1
+        uses: reviewdog/action-golangci-lint@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,13 +20,5 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
 
-      - name: Cache
-        uses: actions/cache@v2
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
       - name: Test
         run: go test -v -race ./...

--- a/hcledit.go
+++ b/hcledit.go
@@ -8,7 +8,7 @@ package hcledit
 import (
 	"fmt"
 
-	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/zclconf/go-cty/cty"
 

--- a/hcledit.go
+++ b/hcledit.go
@@ -8,7 +8,7 @@ package hcledit
 import (
 	"fmt"
 
-	"github.com/hashicorp/hcl/v2"
+	hcl "github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/zclconf/go-cty/cty"
 

--- a/hcledit.go
+++ b/hcledit.go
@@ -173,6 +173,12 @@ func (h *HCLEditor) Delete(queryStr string, opts ...Option) error {
 	return w.Walk(h.writeFile.Body(), queries, 0, []string{})
 }
 
+// CustomEdit executes a custom function on the underlying file
+func (h *HCLEditor) CustomEdit(fn func(*hclwrite.Body) error) error {
+	defer h.reload()
+	return fn(h.writeFile.Body())
+}
+
 // reload re-parse the HCL file. Some operation causes like `WithAfter` modifies Body token structure
 // drastically (it re-construct it from scratch...) and, because of it, some operation will not work
 // properly after it


### PR DESCRIPTION
## WHAT
This PR adds a `CustomEdit` function to allow custom functions to be run on the file, to support more detailed edits.

## WHY
There are cases where the existing functions do not support the required use case. This includes cases where there's identical provider blocks and we only want to modify one. To support future use cases as well where this may be an issue, I went with a custom function approach. This will require users to know more low level details, but this is meant for more advanced use cases anyway. As such, this will not be added to the CLI tool.
