### PR TITLE
[hcledit] add a way to get EvalContext from HCLEditor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,15 +1,24 @@
 module go.mercari.io/hcledit
 
-go 1.16
+go 1.22
 
 require (
 	github.com/google/go-cmp v0.5.7
 	github.com/hashicorp/hcl/v2 v2.10.1
-	github.com/kr/pretty v0.2.0 // indirect
 	github.com/spf13/cobra v1.4.0
 	github.com/zclconf/go-cty v1.8.3
+	github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b
+	gopkg.in/yaml.v2 v2.4.0
+)
+
+require (
+	github.com/agext/levenshtein v1.2.1 // indirect
+	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/kr/pretty v0.2.0 // indirect
+	github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
-	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,6 @@
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-dump v0.0.0-20180507223929-23540a00eaa3/go.mod h1:oL81AME2rN47vu18xqj1S1jPIPuN7afo62yKTNn3XMM=
-github.com/apparentlymart/go-textseg v1.0.0 h1:rRmlIsPEEhUTIKQb7T++Nz/A5Q6C9IuX2wFoYVvnCs0=
 github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/Nj9VFpLOpjS5yuumk=
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
@@ -47,6 +46,7 @@ github.com/zclconf/go-cty v1.2.0/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q
 github.com/zclconf/go-cty v1.8.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
 github.com/zclconf/go-cty v1.8.3 h1:48gwZXrdSADU2UW9eZKHprxAI7APZGW9XmExpJpSjT0=
 github.com/zclconf/go-cty v1.8.3/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
+github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b h1:FosyBZYxY34Wul7O/MSKey3txpPYyCqVO5ZyceuQJEI=
 github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b/go.mod h1:ZRKQfBXbGkpdV6QMzT3rU1kSTAnfu1dO8dPKjYprgj8=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/hcledit.go
+++ b/hcledit.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/zclconf/go-cty/cty"
 
@@ -23,6 +24,7 @@ type HCLEditor struct {
 	path      string
 	filename  string
 	writeFile *hclwrite.File
+	hclFile   *hcl.File
 }
 
 // TODO(slewiskelly): Should these be exported?
@@ -40,6 +42,86 @@ func RawVal(rawString string) *handler.RawVal {
 	return &handler.RawVal{
 		RawString: rawString,
 	}
+}
+
+type root struct {
+	Variables []*variable `hcl:"variable,block"`
+	Locals    []*local    `hcl:"locals,block"`
+}
+
+type variable struct {
+	Name    string         `hcl:"name,label"`
+	Default hcl.Expression `hcl:"default,optional"`
+	Remain  hcl.Body       `hcl:",remain"`
+}
+
+type local struct {
+	Remain hcl.Body `hcl:",remain"`
+}
+
+func (h *HCLEditor) updateVariables(ctx *hcl.EvalContext, vars ...*variable) {
+	const key = "var"
+	children := make(map[string]cty.Value)
+	for _, v := range vars {
+		value, _ := v.Default.Value(ctx)
+
+		children[v.Name] = value
+
+		// TODO(ryan-ph): This needs to handle the case where key already
+		// exists in this map. If it does exist, we need to merge the vals
+		//
+		// update context as other blocks or attrs can refer to values we just
+		// parsed
+		ctx.Variables[key] = cty.ObjectVal(children)
+	}
+}
+
+func (h *HCLEditor) updateLocals(ctx *hcl.EvalContext, locals ...*local) {
+	const key = "local"
+	children := make(map[string]cty.Value)
+	for _, l := range locals {
+		attrs, _ := l.Remain.JustAttributes()
+		for name, attr := range attrs {
+			value, _ := attr.Expr.Value(ctx)
+
+			children[name] = value
+
+			// TODO(ryan-ph): This needs to handle the case where key already
+			// exists in this map. If it does exist, we need to merge the vals
+			//
+			// update context as other blocks or attrs can refer to values we just
+			// parsed
+			ctx.Variables[key] = cty.ObjectVal(children)
+		}
+	}
+}
+
+// TODO(ryan-ph): This currently only handles locals and variable blocks. Other
+// blocks will require defining / importing structs with struct tags for the
+// necessary blocks.
+func (h *HCLEditor) UpdateCtx(ctx *hcl.EvalContext) error {
+	var r root
+	if diags := gohcl.DecodeBody(h.hclFile.Body, ctx, &r); diags.HasErrors() {
+		return diags
+	}
+
+	// TODO(ryan-ph): really this needs to do a topo-sort of _all_ of the blocks
+	// held in Root to determine the order in which things should be evaluated.
+	// This current implementation will not work well with blocks which refer
+	// to other blocks that are defined later. For example, this will produce
+	// an unknown value as we are currently just evaluating variables, then
+	// locals top-to-bottom:
+	// ```hcl
+	// locals {
+	//   team_name = "team-${local.owner}"
+	// }
+	// locals {
+	//   owner = "admin"
+	// }
+	// ```
+	h.updateVariables(ctx, r.Variables...)
+	h.updateLocals(ctx, r.Locals...)
+	return nil
 }
 
 // Create creates attributes and blocks matched with the given query
@@ -75,6 +157,7 @@ func (h *HCLEditor) Create(queryStr string, value interface{}, opts ...Option) e
 // The results are map of mached key and its value.
 //
 // It returns error if it does not match any key.
+// TODO(ryan-ph): this needs to take *hcl.EvalContext)
 func (h *HCLEditor) Read(queryStr string, opts ...Option) (map[string]interface{}, error) {
 	defer h.reload()
 
@@ -89,6 +172,7 @@ func (h *HCLEditor) Read(queryStr string, opts ...Option) (map[string]interface{
 	}
 
 	results := make(map[string]cty.Value)
+	// TODO(ryan-ph): this needs to take *hcl.EvalContext)
 	hdlr, err := handler.NewReadHandler(results)
 	if err != nil {
 		return nil, err

--- a/internal/handler/read.go
+++ b/internal/handler/read.go
@@ -41,6 +41,7 @@ func (h *readHandler) HandleObject(object *ast.Object, name string, keyTrail []s
 	return nil
 }
 
+// TODO(ryan-ph): this needs to take *hcl.EvalContext)
 func parse(buf []byte, name string) (cty.Value, error) {
 	file, diags := hclsyntax.ParseConfig(buf, "", hcl.Pos{Line: 1, Column: 1})
 	if diags.HasErrors() {
@@ -48,6 +49,7 @@ func parse(buf []byte, name string) (cty.Value, error) {
 	}
 
 	body := file.Body.(*hclsyntax.Body)
+	// TODO(ryan-ph): this needs to take *hcl.EvalContext)
 	v, diags := body.Attributes[name].Expr.Value(nil)
 	if diags.HasErrors() {
 		return cty.Value{}, diags

--- a/read.go
+++ b/read.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 )
 
@@ -52,8 +53,14 @@ func Read(r io.Reader, filename string) (*HCLEditor, error) {
 		return nil, diags
 	}
 
+	hclFile, diags := hclsyntax.ParseConfig(buf, filename, hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
 	return &HCLEditor{
 		filename:  filename,
 		writeFile: writeFile,
+		hclFile:   hclFile,
 	}, nil
 }


### PR DESCRIPTION
## WHAT

Adds a way to pull information from an `HCLEditor` into `EvalContext` so that we can evaluate values in multiple files.

This PR does _not_ update the CLI to be able to take multiple HCL files to read interpolated values.

## WHY

Currently `HCLEditor.Read()` cannot parse any interpolated values. This is somewhat necessary when using this module outside of the CLI where we do have access to multiple different `HCLEditor` instances that may contain concrete values that can be used during evaluation.

As a simple implementation, expose some APIs that users can use to parse and update `EvalContext` in top-to-bottom order starting with variables, then locals.