### PR TITLE
[hcledit/create] add comments to block handler

### DIFF
--- a/hcledit_test.go
+++ b/hcledit_test.go
@@ -13,9 +13,11 @@ import (
 )
 
 func TestCreate(t *testing.T) {
+	defaultOpts := []hcledit.Option{}
 	cases := map[string]struct {
 		input string
 		query string
+		opts  []hcledit.Option
 		value interface{}
 		want  string
 	}{
@@ -23,6 +25,7 @@ func TestCreate(t *testing.T) {
 			input: `
 `,
 			query: "attribute",
+			opts:  defaultOpts,
 			value: "C",
 			want: `
 attribute = "C"
@@ -35,6 +38,7 @@ block "label" {
 }
 `,
 			query: "block.label.attribute",
+			opts:  defaultOpts,
 			value: "C",
 			want: `
 block "label" {
@@ -51,6 +55,7 @@ block1 "label1" {
 }
 `,
 			query: "block1.label1.block2.label2.attribute",
+			opts:  defaultOpts,
 			value: "C",
 			want: `
 block1 "label1" {
@@ -70,6 +75,7 @@ block "label" "label2" {
 }
 `,
 			query: "block.label.*.attribute",
+			opts:  defaultOpts,
 			value: "C",
 			want: `
 block "label" "label1" {
@@ -88,6 +94,7 @@ object = {
 }
 `,
 			query: "object.attribute",
+			opts:  defaultOpts,
 			value: "C",
 			want: `
 object = {
@@ -103,6 +110,7 @@ object = {
 }
 `,
 			query: "object.attribute2",
+			opts:  defaultOpts,
 			value: "C",
 			want: `
 object = {
@@ -116,8 +124,22 @@ object = {
 			input: `
 `,
 			query: "block",
+			opts:  defaultOpts,
 			value: hcledit.BlockVal("label1", "label2"),
 			want: `
+block "label1" "label2" {
+}
+`,
+		},
+
+		"Block with comment": {
+			input: `
+`,
+			query: "block",
+			opts:  []hcledit.Option{hcledit.WithComment("test comment")},
+			value: hcledit.BlockVal("label1", "label2"),
+			want: `
+// test comment
 block "label1" "label2" {
 }
 `,
@@ -127,6 +149,7 @@ block "label1" "label2" {
 			input: `
 `,
 			query: "object1",
+			opts:  defaultOpts,
 			value: hcledit.RawVal(`{
   object2 = {
     attribute1 = "str1"
@@ -149,7 +172,7 @@ object1 = {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if err := editor.Create(tc.query, tc.value); err != nil {
+			if err := editor.Create(tc.query, tc.value, tc.opts...); err != nil {
 				t.Fatal(err)
 			}
 

--- a/internal/handler/block.go
+++ b/internal/handler/block.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"strings"
 	"fmt"
 
 	"github.com/hashicorp/hcl/v2/hclwrite"
@@ -13,16 +14,26 @@ type BlockVal struct {
 }
 
 type blockHandler struct {
-	labels []string
+	labels  []string
+	comment string
 }
 
-func newBlockHandler(labels []string) (Handler, error) {
+func newBlockHandler(labels []string, comment string) (Handler, error) {
 	return &blockHandler{
-		labels: labels,
+		labels:  labels,
+		comment: comment,
 	}, nil
 }
 
 func (h *blockHandler) HandleBody(body *hclwrite.Body, name string, _ []string) error {
+	if h.comment != "" {
+		if !strings.HasPrefix(h.comment, "//") {
+			h.comment = fmt.Sprintf("// %s", h.comment)
+		}
+		tokens := beforeTokens(h.comment, false)
+		body.AppendUnstructuredTokens(tokens)
+	}
+
 	body.AppendNewBlock(name, h.labels)
 	return nil
 }

--- a/internal/handler/block.go
+++ b/internal/handler/block.go
@@ -26,13 +26,7 @@ func newBlockHandler(labels []string, comment string) (Handler, error) {
 }
 
 func (h *blockHandler) HandleBody(body *hclwrite.Body, name string, _ []string) error {
-	if h.comment != "" {
-		if !strings.HasPrefix(h.comment, "//") {
-			h.comment = fmt.Sprintf("// %s", h.comment)
-		}
-		tokens := beforeTokens(h.comment, false)
-		body.AppendUnstructuredTokens(tokens)
-	}
+	body.AppendUnstructuredTokens(beforeTokens(fmt.Sprintf("// %s", strings.TrimSpace(strings.TrimPrefix(h.comment, "//"))), false))
 
 	body.AppendNewBlock(name, h.labels)
 	return nil

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -18,7 +18,7 @@ type Handler interface {
 func New(input interface{}, comment, afterKey string, beforeNewline bool) (Handler, error) {
 	switch v := input.(type) {
 	case *BlockVal:
-		return newBlockHandler(v.Labels)
+		return newBlockHandler(v.Labels, comment)
 	case *RawVal:
 		return newRawHandler(v.RawString)
 	}


### PR DESCRIPTION
## WHAT

title

## WHY

If we're automatically generating HCL, we likely want to leave comments on generated blocks to let readers know the block was automatically generated. This adds this functionality.
