### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @tcnksm @drlau @b4b4r07 @slewiskelly @micnncim @ryan-ph @dtan4 @yanolab @suzuki-shunsuke @ryotafuwa-dev
+* @tcnksm @drlau @slewiskelly @micnncim @ryan-ph @dtan4 @yanolab @suzuki-shunsuke @ryotafuwa-dev


### PR DESCRIPTION
## WHAT

Update CODEOWNERS based on the latest status

## WHY

To keep the list of maintainers up-to-date