### PR TITLE
[hcledit/create] add new line before appending a block level comment

### DIFF
--- a/hcledit_test.go
+++ b/hcledit_test.go
@@ -139,6 +139,21 @@ block "label1" "label2" {
 			opts:  []hcledit.Option{hcledit.WithComment("test comment")},
 			value: hcledit.BlockVal("label1", "label2"),
 			want: `
+
+// test comment
+block "label1" "label2" {
+}
+`,
+		},
+
+		"Append block with comment": {
+			input: `
+prev {}`,
+			query: "block",
+			opts:  []hcledit.Option{hcledit.WithComment("test comment")},
+			value: hcledit.BlockVal("label1", "label2"),
+			want: `
+prev {}
 // test comment
 block "label1" "label2" {
 }

--- a/internal/handler/block.go
+++ b/internal/handler/block.go
@@ -30,7 +30,7 @@ func (h *blockHandler) HandleBody(body *hclwrite.Body, name string, _ []string) 
 		body.AppendUnstructuredTokens(
 			beforeTokens(
 				fmt.Sprintf("// %s", strings.TrimSpace(strings.TrimPrefix(h.comment, "//"))),
-				false,
+				true,	
 			),
 		)
 	}


### PR DESCRIPTION
## WHAT

title

## WHY

Currently, this appends the comment to the line prior to the new block, which is not what we want. The previous behavior would result in:
```hcl
prev {
} // comment
block "new block" {
}
```

This fixes this to do:
```hcl
prev {
}
// comment
block "new block" {
}
```