### PR TITLE
[goreleaser] add name template

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,12 +15,14 @@ builds:
       - windows
       - darwin
 archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
+  - name_template: >-
+    {{- .ProjectName }}_
+    {{- .Version }}_
+    {{- title .Os }}_
+    {{- if eq .Arch "amd64" }}x86_64
+    {{- else if eq .Arch "386" }}i386
+    {{- else }}{{ .Arch }}{{ end }}
+    {{- if .Arm }}v{{ .Arm }}{{ end -}}
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
## WHAT

title

## WHY

Goreleaser workflow is broken because `archives.replacements` is no longer valid. This should fix the automated releases I think 🤔 