### PR TITLE
[goreleaser] fix indentation for name_template

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,13 +16,13 @@ builds:
       - darwin
 archives:
   - name_template: >-
-    {{- .ProjectName }}_
-    {{- .Version }}_
-    {{- title .Os }}_
-    {{- if eq .Arch "amd64" }}x86_64
-    {{- else if eq .Arch "386" }}i386
-    {{- else }}{{ .Arch }}{{ end }}
-    {{- if .Arm }}v{{ .Arm }}{{ end -}}
+      {{- .ProjectName }}_
+      {{- .Version }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end -}}
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
## WHAT

title

## WHY

The YAML was previously invalid 🤔 
Since we're using a multiline string with `>-`, we need to make sure we're not at the same indentation level that YAML expects another key