### PR TITLE
chore(goreleaser): fix deprecation warning

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,9 +36,9 @@ changelog:
       - Merge pull request
       - Merge branch
 brews:
-  - tap:
+  - repository:
       owner: mercari
       name: hcledit
-    folder: Formula
+    directory: Formula
     homepage: https://github.com/mercari/hcledit
     description: CLI to edit HCL configurations


### PR DESCRIPTION
## WHAT
(Write the change being made with this pull request)

Fix .goreleaser.yml.

## WHY
(Write the motivation why you submit this pull request)

goreleaser outputs warning.
These settings were deprecated.

```console
$ goreleaser release --snapshot
    • DEPRECATED:  brews.folder  should not be used anymore, check https://goreleaser.com/deprecations#brewsfolder for more info
    • DEPRECATED:  brews.tap  should not be used anymore, check https://goreleaser.com/deprecations#brewstap for more info
```

- https://goreleaser.com/deprecations/#brewstap
- https://goreleaser.com/deprecations/#brewsfolder