### PR TITLE
fix(cicd/release): single quotes around go-version in `actions/setup-go@v4`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20
+          go-version: '1.20'
 
       - name: Cache
         uses: actions/cache@v2


### PR DESCRIPTION
## WHAT
(Write the change being made with this pull request)

As the title suggests.

## WHY
(Write the motivation why you submit this pull request)

This PR is intended to fix the release workflow.

One of the causes for the release workflow not working properly can be attributed to the way of specifying the go version in `actions/setup-go`.

This is noted in the README of `actions/setup-go` as follows:

> The recommendation is based on the YAML parser's behavior, which interprets non-wrapped values as numbers and, in the case of version 1.20, trims it down to 1.2, which may not be very obvious.

https://github.com/actions/setup-go/blob/4ab57d7ea2fd0c9948210b2e0784e280674e7144/README.md?plain=1#L69-L75

You can confirm that `Go@v1.2.x` is installed from these logs.

```sh
Run actions/setup-go@v4
  with:
    go-version: 1.2
    check-latest: false
    token: ***
    cache: true
Setup go version spec 1.2
Attempting to download 1.2...
matching 1.2...
Not found in manifest.  Falling back to download directly from Go
Install from dist
Acquiring go1.2.2 from https://storage.googleapis.com/golang/go1.2.2.linux-amd64.tar.gz
Extracting Go...
/usr/bin/tar xz --warning=no-unknown-keyword --overwrite -C /home/runner/work/_temp/079692ff-a4af-499c-9e26-5532cd7c757c -f /home/runner/work/_temp/1058dbd3-9393-472f-a3e6-d51e4a830391
Successfully extracted go to /home/runner/work/_temp/079692ff-a4af-499c-9e26-5532cd7c757c
Adding to the cache ...
Successfully cached go to /opt/hostedtoolcache/go/1.2.2/x64
Added go to the path
Setting GOROOT for Go version < 1.9
Successfully set up Go version 1.2
/opt/hostedtoolcache/go/1.2.2/x64/bin/go env GOMODCACHE
/opt/hostedtoolcache/go/1.2.2/x64/bin/go env GOCACHE


Warning: Restore cache failed: Could not get cache folder paths.
go version go1.2.2 linux/amd64

go env
  GOARCH="amd64"
  GOBIN=""
  GOCHAR="6"
  GOEXE=""
  GOHOSTARCH="amd64"
  GOHOSTOS="linux"
  GOOS="linux"
  GOPATH=""
  GORACE=""
  GOROOT="/opt/hostedtoolcache/go/1.2.2/x64"
  GOTOOLDIR="/opt/hostedtoolcache/go/1.2.2/x64/pkg/tool/linux_amd64"
  TERM="dumb"
  CC="gcc"
  GOGCCFLAGS="-g -O2 -fPIC -m64 -pthread"
  CXX="g++"
  CGO_ENABLED="1"
```
https://github.com/mercari/hcledit/actions/runs/8813629424/job/24191778278#step:3:21

## Related

- #106
- #108 
- #109 