### PR TITLE
chore: set CGO_ENABLED=0

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 before:
   hooks:
     - go mod download
@@ -14,6 +15,8 @@ builds:
       - linux
       - windows
       - darwin
+    env:
+      - CGO_ENABLED=0
 archives:
   - name_template: >-
       {{- .ProjectName }}_


### PR DESCRIPTION
## WHAT
(Write the change being made with this pull request)

Set `CGO_ENABLED=0` when building hcledit.

https://medium.com/@pengcheng1222/exploring-cgo-enabled-in-go-23cf5cf2fe88

## WHY
(Write the motivation why you submit this pull request)

To resolve the issue.

```
6_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by hcledit)
hcledit: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by hcledit)
```

Currently, hcledit depends on libc so hcledit doesn't work without libc.
By setting `CGO_ENABLED=0` when building hcledit, hcledit works without libc.