### PR TITLE
[ci/workflows] run `docker build` on PRs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - '*'
+  pull_request:
 
 jobs:
   docker:
@@ -44,7 +45,8 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
-          push: true
+          # Only push if there was a tag pushed
+          push: ${{ github.event_name != 'pull_request' }}
           cache-from: type=local,src=/tmp/.buildx/cache
           cache-to: type=local,dest=/tmp/.buildx/cache,mode=max
           tags: |


### PR DESCRIPTION
This will catch if any changes break the build process. This is inspired because dependenabot auto-merged a change that broke the build process because there was no CI check on PRs to ensure build continues to work.

Actual fix for the build is in https://github.com/mercari/hcledit/pull/120

