### PR TITLE
[workflows/release] have `goreleaser` open PRs to update tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   goreleaser:
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,11 @@ on:
 
 jobs:
   goreleaser:
+
+    # These permissions are needed for Goreleaser to push a branch and open a
+    # PR to update the tap.
     permissions:
+      contents: write
       pull-requests: write
     runs-on: ubuntu-latest
     steps:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -35,7 +35,7 @@ changelog:
   filters:
     exclude:
       - '^docs:'
-      - '^test:'      
+      - '^test:'
       - Merge pull request
       - Merge branch
 brews:
@@ -45,3 +45,5 @@ brews:
     directory: Formula
     homepage: https://github.com/mercari/hcledit
     description: CLI to edit HCL configurations
+    pull_request:
+      enabled: true


### PR DESCRIPTION
Currently `goreleaser` is attempting to push directly to trunk which is blocked by our different rulesets. Instead, we can have `goreleaser` open a PR and that can be merged manually so that we have no exceptions for all changes being made through a PR.

https://github.com/mercari/hcledit/issues/113
