### PR TITLE
[feat] add an option for queryStr separator

### DIFF
--- a/hcledit.go
+++ b/hcledit.go
@@ -48,12 +48,14 @@ func RawVal(rawString string) *handler.RawVal {
 func (h *HCLEditor) Create(queryStr string, value interface{}, opts ...Option) error {
 	defer h.reload()
 
-	opt := &option{}
+	opt := &option{
+		querySeparator: ".",
+	}
 	for _, optFunc := range opts {
 		optFunc(opt)
 	}
 
-	queries, err := query.Build(queryStr)
+	queries, err := query.Build(queryStr, opt.querySeparator)
 	if err != nil {
 		return err
 	}
@@ -78,12 +80,14 @@ func (h *HCLEditor) Create(queryStr string, value interface{}, opts ...Option) e
 func (h *HCLEditor) Read(queryStr string, opts ...Option) (map[string]interface{}, error) {
 	defer h.reload()
 
-	opt := &option{}
+	opt := &option{
+		querySeparator: ".",
+	}
 	for _, optFunc := range opts {
 		optFunc(opt)
 	}
 
-	queries, err := query.Build(queryStr)
+	queries, err := query.Build(queryStr, opt.querySeparator)
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +126,9 @@ func (h *HCLEditor) Read(queryStr string, opts ...Option) (map[string]interface{
 func (h *HCLEditor) Update(queryStr string, value interface{}, opts ...Option) error {
 	defer h.reload()
 
-	opt := &option{}
+	opt := &option{
+		querySeparator: ".",
+	}
 	for _, optFunc := range opts {
 		optFunc(opt)
 	}
@@ -139,7 +145,7 @@ func (h *HCLEditor) Update(queryStr string, value interface{}, opts ...Option) e
 		return fmt.Errorf("WithNewLine is not supported for Update")
 	}
 
-	queries, err := query.Build(queryStr)
+	queries, err := query.Build(queryStr, opt.querySeparator)
 	if err != nil {
 		return err
 	}
@@ -163,12 +169,14 @@ func (h *HCLEditor) Update(queryStr string, value interface{}, opts ...Option) e
 func (h *HCLEditor) Delete(queryStr string, opts ...Option) error {
 	defer h.reload()
 
-	opt := &option{}
+	opt := &option{
+		querySeparator: ".",
+	}
 	for _, optFunc := range opts {
 		optFunc(opt)
 	}
 
-	queries, err := query.Build(queryStr)
+	queries, err := query.Build(queryStr, opt.querySeparator)
 	if err != nil {
 		return err
 	}

--- a/hcledit.go
+++ b/hcledit.go
@@ -49,7 +49,7 @@ func (h *HCLEditor) Create(queryStr string, value interface{}, opts ...Option) e
 	defer h.reload()
 
 	opt := &option{
-		querySeparator: ".",
+		querySeparator: '.',
 	}
 	for _, optFunc := range opts {
 		optFunc(opt)
@@ -81,7 +81,7 @@ func (h *HCLEditor) Read(queryStr string, opts ...Option) (map[string]interface{
 	defer h.reload()
 
 	opt := &option{
-		querySeparator: ".",
+		querySeparator: '.',
 	}
 	for _, optFunc := range opts {
 		optFunc(opt)
@@ -127,7 +127,7 @@ func (h *HCLEditor) Update(queryStr string, value interface{}, opts ...Option) e
 	defer h.reload()
 
 	opt := &option{
-		querySeparator: ".",
+		querySeparator: '.',
 	}
 	for _, optFunc := range opts {
 		optFunc(opt)
@@ -170,7 +170,7 @@ func (h *HCLEditor) Delete(queryStr string, opts ...Option) error {
 	defer h.reload()
 
 	opt := &option{
-		querySeparator: ".",
+		querySeparator: '.',
 	}
 	for _, optFunc := range opts {
 		optFunc(opt)

--- a/hcledit_test.go
+++ b/hcledit_test.go
@@ -127,7 +127,7 @@ object = {
 }
 `,
 			query: "object|attribute3.value",
-			opts:  []hcledit.Option{hcledit.WithQuerySeparator("|")},
+			opts:  []hcledit.Option{hcledit.WithQuerySeparator('|')},
 			value: "D",
 			want: `
 object = {

--- a/hcledit_test.go
+++ b/hcledit_test.go
@@ -120,6 +120,23 @@ object = {
 `,
 		},
 
+		"AttributeWithCommaInObject": {
+			input: `
+object = {
+  attribute2 = "C"
+}
+`,
+			query: "object|attribute3.value",
+			opts:  []hcledit.Option{hcledit.WithQuerySeparator("|")},
+			value: "D",
+			want: `
+object = {
+  attribute2       = "C"
+  attribute3.value = "D"
+}
+`,
+		},
+
 		"Block": {
 			input: `
 `,

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -30,9 +30,9 @@ func (c *queryWildcard) Key() string {
 	return "*"
 }
 
-func Build(src string) ([]Query, error) {
+func Build(src, querySeparator string) ([]Query, error) {
 	var queries []Query
-	for _, q := range strings.Split(src, ".") {
+	for _, q := range strings.Split(src, querySeparator) {
 		if q == "*" {
 			queries = append(queries, &queryWildcard{})
 		} else {

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -30,9 +30,9 @@ func (c *queryWildcard) Key() string {
 	return "*"
 }
 
-func Build(src, querySeparator string) ([]Query, error) {
+func Build(src string, querySeparator rune) ([]Query, error) {
 	var queries []Query
-	for _, q := range strings.Split(src, querySeparator) {
+	for _, q := range strings.Split(src, string([]rune{querySeparator})) {
 		if q == "*" {
 			queries = append(queries, &queryWildcard{})
 		} else {

--- a/option.go
+++ b/option.go
@@ -5,7 +5,7 @@ type option struct {
 	afterKey                string
 	beforeNewline           bool
 	readFallbackToRawString bool
-	querySeparator          string
+	querySeparator          rune
 }
 
 // Option configures specific behavior for specific HCLEditor operations.
@@ -43,8 +43,8 @@ func WithReadFallbackToRawString() Option {
 }
 
 // This sets a separator for queryStr in HCLEditor funcs. The default separator is ".".
-func WithQuerySeparator(chr string) Option {
+func WithQuerySeparator(r rune) Option {
 	return func(opt *option) {
-		opt.querySeparator = chr
+		opt.querySeparator = r
 	}
 }

--- a/option.go
+++ b/option.go
@@ -5,6 +5,7 @@ type option struct {
 	afterKey                string
 	beforeNewline           bool
 	readFallbackToRawString bool
+	querySeparator          string
 }
 
 // Option configures specific behavior for specific HCLEditor operations.
@@ -38,5 +39,12 @@ func WithNewLine() Option {
 func WithReadFallbackToRawString() Option {
 	return func(opt *option) {
 		opt.readFallbackToRawString = true
+	}
+}
+
+// This sets a separator for queryStr in HCLEditor funcs. The default separator is ".".
+func WithQuerySeparator(chr string) Option {
+	return func(opt *option) {
+		opt.querySeparator = chr
 	}
 }

--- a/option_test.go
+++ b/option_test.go
@@ -239,6 +239,21 @@ object = {
 }
 `,
 		},
+
+		"CreateWithQuerySeparator": {
+			input: `
+object = {
+}
+`,
+			exec: func(editor *hcledit.HCLEditor) error {
+				return editor.Create("object/attribute", "str", hcledit.WithQuerySeparator("/"))
+			},
+			want: `
+object = {
+  attribute = "str"
+}
+`,
+		},
 	}
 
 	for name, tc := range cases {

--- a/option_test.go
+++ b/option_test.go
@@ -246,7 +246,7 @@ object = {
 }
 `,
 			exec: func(editor *hcledit.HCLEditor) error {
-				return editor.Create("object/attribute", "str", hcledit.WithQuerySeparator("/"))
+				return editor.Create("object/attribute", "str", hcledit.WithQuerySeparator('/'))
 			},
 			want: `
 object = {


### PR DESCRIPTION
## WHAT
(Write the change being made with this pull request)
title 

## WHY
(Write the motivation why you submit this pull request)
Terraform allows comma-separated attributes (e.g. aliased providers like google.common inside a module). In order to modify attributes with comma in its name, we need a way to specify the queryStr split separator charactor.

### Behavior
given: 
```
module "A" {
  providers = {
    google.aliasA = google.aliasA
  }
}
```
where:
```
hcledit.Create("module.A.providers.google.aliasB", RawVal("google.aliasB"))
```
then:
```
module "A" {
  providers = {
    google.aliasA = google.aliasA
  }
}
```
Because queryStr considers all the commas as the query separator.

target:
```
module "A" {
  providers = {
    google.aliasA = google.aliasA
    google.aliasB = google.aliasB
  }
}
```