### PR TITLE
[feat]: BlockVal should reflects WithNewLine option

### DIFF
--- a/hcledit_test.go
+++ b/hcledit_test.go
@@ -160,6 +160,19 @@ block "label1" "label2" {
 `,
 		},
 
+		"Block with new line": {
+			input: `
+`,
+			query: "block",
+			opts:  []hcledit.Option{hcledit.WithNewLine()},
+			value: hcledit.BlockVal("label1", "label2"),
+			want: `
+
+block "label1" "label2" {
+}
+`,
+		},
+
 		"Raw": {
 			input: `
 `,

--- a/internal/handler/block.go
+++ b/internal/handler/block.go
@@ -14,27 +14,32 @@ type BlockVal struct {
 }
 
 type blockHandler struct {
-	labels  []string
-	comment string
+	labels        []string
+	comment       string
+	beforeNewLine bool
 }
 
-func newBlockHandler(labels []string, comment string) (Handler, error) {
+func newBlockHandler(labels []string, comment string, beforeNewLine bool) (Handler, error) {
 	return &blockHandler{
-		labels:  labels,
-		comment: comment,
+		labels:        labels,
+		comment:       comment,
+		beforeNewLine: beforeNewLine,
 	}, nil
 }
 
 func (h *blockHandler) HandleBody(body *hclwrite.Body, name string, _ []string) error {
 	if h.comment != "" {
+		// Note: intuitively, adding a new line should be determined by `h.beforeNewLine`.
+		// However, in order to archive the backward compatibility, we add a new line whenever comment is set to a non empty string.
 		body.AppendUnstructuredTokens(
 			beforeTokens(
 				fmt.Sprintf("// %s", strings.TrimSpace(strings.TrimPrefix(h.comment, "//"))),
 				true,
 			),
 		)
+	} else {
+		body.AppendUnstructuredTokens(beforeTokens(h.comment, h.beforeNewLine))
 	}
-
 	body.AppendNewBlock(name, h.labels)
 	return nil
 }

--- a/internal/handler/block.go
+++ b/internal/handler/block.go
@@ -30,7 +30,7 @@ func newBlockHandler(labels []string, comment string, beforeNewLine bool) (Handl
 func (h *blockHandler) HandleBody(body *hclwrite.Body, name string, _ []string) error {
 	if h.comment != "" {
 		// Note: intuitively, adding a new line should be determined by `h.beforeNewLine`.
-		// However, in order to archive the backward compatibility, we add a new line whenever comment is set to a non empty string.
+		// However, for the backward compatibility, we add a new line whenever comment is set to a non empty string.
 		body.AppendUnstructuredTokens(
 			beforeTokens(
 				fmt.Sprintf("// %s", strings.TrimSpace(strings.TrimPrefix(h.comment, "//"))),

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -18,7 +18,7 @@ type Handler interface {
 func New(input interface{}, comment, afterKey string, beforeNewline bool) (Handler, error) {
 	switch v := input.(type) {
 	case *BlockVal:
-		return newBlockHandler(v.Labels, comment)
+		return newBlockHandler(v.Labels, comment, beforeNewline)
 	case *RawVal:
 		return newRawHandler(v.RawString)
 	}


### PR DESCRIPTION
## WHAT
(Write the change being made with this pull request)
title 

## WHY
(Write the motivation why you submit this pull request)
`Hcledit.Create` with `BlockVal` ignores the WithNewLine option. This PR fixes that.