### PR TITLE
[goreleaser] fix tap config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.22'
 
       - name: Cache
         uses: actions/cache@v2

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -42,8 +42,8 @@ brews:
   - repository:
       owner: mercari
       name: hcledit
+      pull_request:
+        enabled: true
     directory: Formula
     homepage: https://github.com/mercari/hcledit
     description: CLI to edit HCL configurations
-    pull_request:
-      enabled: true


### PR DESCRIPTION
The `pull_request` key should be nested under `repository`.
