### PR TITLE
[goreleaser] specify the main branch

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -44,6 +44,10 @@ brews:
       name: hcledit
       pull_request:
         enabled: true
+        base:
+          owner: mercari
+          name: hcledit
+          branch: main
     directory: Formula
     homepage: https://github.com/mercari/hcledit
     description: CLI to edit HCL configurations


### PR DESCRIPTION
I think this is the cause for 404 error when `goreleaser` attempts to find the default branch.