### PR TITLE
[goreleaser] add `packages: write` permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      packages: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
I believe this is the last permission needed to allow `goreleaser` to upload the artifacts needed to create a release.

This PR should fix this error message found in this workflow run: https://github.com/mercari/hcledit/actions/runs/10054218246/job/27788393692
```
 ⨯ release failed after 1m8s                error=scm releases: failed to publish artifacts: failed to upload hcledit_0.0.15_Linux_x86_64.tar.gz after 1 tries: POST https://uploads.github.com/repos/mercari/hcledit/releases/166614281/assets?name=hcledit_0.0.15_Linux_x86_64.tar.gz: 422 Validation Failed [{Resource:ReleaseAsset Field:name Code:already_exists Message:}]
```
