### PR TITLE
Fallback to raw values in object attributes

### DIFF
--- a/hcledit_test.go
+++ b/hcledit_test.go
@@ -461,6 +461,20 @@ attribute = local.var
 			},
 		},
 
+		"fallback to absolute variable name in object": {
+			input: `
+object = {
+	attribute = local.var
+}
+`,
+			options:   []hcledit.Option{hcledit.WithReadFallbackToRawString()},
+			expectErr: true,
+			query:     "object.attribute",
+			want: map[string]interface{}{
+				"object.attribute": "local.var",
+			},
+		},
+
 		"fallback to uninterpolated string": {
 			input: `
 attribute = "some-${local.var}"

--- a/internal/handler/read.go
+++ b/internal/handler/read.go
@@ -36,8 +36,9 @@ func (h *readHandler) HandleBody(body *hclwrite.Body, name string, keyTrail []st
 
 func (h *readHandler) HandleObject(object *ast.Object, name string, keyTrail []string) error {
 	buf := object.GetObjectAttribute(name).BuildTokens().Bytes()
-	value, err := parse(buf, name, h.fallbackToRawString)
-	if err != nil {
+	fallback := h.fallbackToRawString
+	value, err := parse(buf, name, fallback)
+	if err != nil && !fallback {
 		return err
 	}
 	h.results[strings.Join(keyTrail, ".")] = value


### PR DESCRIPTION
## WHAT
If fallback option is enabled, add parsed value to results even if there is an error (in objects)

## WHY
At the moment, the fallback option doesn't work for object attributes
