### PR TITLE
[goreleaser] specify branch name for PR

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -42,6 +42,7 @@ brews:
   - repository:
       owner: mercari
       name: hcledit
+      branch: update-brew-formula
       pull_request:
         enabled: true
         base:


### PR DESCRIPTION
This property defaults to the repo's default branch which is causing goreleaser to attempt to merge directly to `main`. Setting this property to another branch name should hopefully allow it to create a PR and successfully update the tap.